### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ different events are selected out of all possibilities (post-selection rules).
 All experiments that our package is applied to can be described by a graph. When describing state creation using SPDC
 each edge can be interpreted as a pair-creation. In this case all edges of the complete graph can be considered
 physically legitimate. When describing other experiments edges can be interpreted differently. Not every edge will be
-physically meaningful. Consequentially there are constraints on which connections of the complete graph are used in the
+physically meaningful. Consequently there are constraints on which connections of the complete graph are used in the
 optimization.
 
 *(A) Single Photon Sources and Input Photons*
@@ -132,7 +132,7 @@ Heralding is a less strict form of selecting events. Instead of putting a detect
 coincidence, only a subset of the paths are detected _heralding_ an output state in the unmeasured paths. This selection
 rule not only allows for possibilities where one photon is in every path (perfect matchings) but also for other
 possibilities (edge covers) as long as they cover the heralding detectors. This can lead to cross-terms that are not
-present when post-selecting for coincidence in all paths. Consequentially it is more difficult to find a graph with
+present when post-selecting for coincidence in all paths. Consequently it is more difficult to find a graph with
 fidelity one, also requiring more experimental resources.
 
 *(B) Single Photon Sources and Input Photons*
@@ -317,7 +317,7 @@ photon sources and two for ancillary detectors.
 If `num_anc` is larger than the sum of lengths of `in_nodes` and `single_emitters`, the necessary amount of particles is
 created through SPDC.
 
-Additionaly `heralding_out` is set to `true` here. The photons corresponding to `out_nodes` will not be detected.
+Additionally `heralding_out` is set to `true` here. The photons corresponding to `out_nodes` will not be detected.
 
 ### Measurement
 

--- a/pytheus/analyzer.py
+++ b/pytheus/analyzer.py
@@ -46,7 +46,7 @@ def string_wrapper(string: str, max_chars_per_line=80,
                    latex = '$',
                    line_break_char = '+' ) -> str:
     """
-    wraps a string to a given line lenght 
+    wraps a string to a given line length 
 
     Parameters
     ----------
@@ -178,9 +178,9 @@ class entanglement_measure():
         calculate the maximal sum of given entanglement measurement 
 
         k_uniform : int, optional
-            which bipartion of lenght k one consider,
+            which bipartion of length k one consider,
             if k = 0:
-            the sum of all possible bipartion and the corrosponding
+            the sum of all possible bipartion and the corresponding
             max value will be returned
 
         """
@@ -203,12 +203,12 @@ class entanglement_measure():
             and 3 splits with 2|2 particles
 
         """
-        lenghts = []
+        lengths = []
         for kk in range(1, 1+int(self.num_par/2)):
             ls = [1 for bipar in hf.get_all_bi_partions(self.num_par)
                   if len(bipar[0]) == kk]
-            lenghts.append(len(ls))
-        return lenghts
+            lengths.append(len(ls))
+        return lengths
 
     def max_values(self,  k_uniform=0, full_vec=False) -> list:
         """
@@ -294,7 +294,7 @@ class state_analyzer():
         self.pre = precision
         self.len = len(self.dic)  # number of summands
         if len(weights) != 0:
-            assert self.len == len(weights), "lenght of weight should match"
+            assert self.len == len(weights), "length of weight should match"
 
         if len(dim) == 0:
             ni = len(list(self.dic.keys())[0])
@@ -359,7 +359,7 @@ class state_analyzer():
             except KeyError:
                 pass
         if all(state_vec == 0) is True:
-            raise TypeError('State Vector is zero for all entrys, hmm?')
+            raise TypeError('State Vector is zero for all entries, hmm?')
         self.norm = np.linalg.norm(state_vec)
         if normalized:
             return state_vec * 1/(self.norm)
@@ -500,7 +500,7 @@ class state_analyzer():
     def calc_k_uniform(self) -> (int, np.array):
         """
         get k uniform of state and normalized vector for each k-bipartion
-        where 1 means  maximal mixed and 0 seperable for that bipartion
+        where 1 means  maximal mixed and 0 separable for that bipartion
         e.g. :
             return is ( 1 , [ [1,1,1,1], [0,1,1] ] ) means state is 1-uniform
             and for all bipartions with cardinality 2 also maximal entangeld
@@ -648,7 +648,7 @@ class analyser():
     def plot_losses(self):
         """
         plots y-axis: concurrence, x-axis: number of edges for a whole
-        list of state dicts, plotvline plots a vertical line for a given positon
+        list of state dicts, plotvline plots a vertical line for a given position
 
         Parameters
         ----------
@@ -806,7 +806,7 @@ class analyser():
                                      dpi=dpi)
             
             if row_len == 1:
-                ax = [ax]  # make ax subscriptable when lenght one
+                ax = [ax]  # make ax subscriptable when length one
             for ii, cover in enumerate(vv):
                 weights_for_cover = [graph[edge] for edge in cover]
                 total_weight += np.prod(weights_for_cover)
@@ -973,7 +973,7 @@ def input_with_check_ints(question: str, restriciton=[]):
                 return user_input
         except:
             counter += 1
-        print(f'inproper input!: try again ({3-counter} trys left)')
+        print(f'inproper input!: try again ({3-counter} tries left)')
 
     import sys
     sys.exit()
@@ -1025,7 +1025,7 @@ def convert_input_path(path: str):
         path = Path(output_dir) / str(folder_list[idx_folder])
 
     path = Path(path)
-    # first check if given path is an absolut path and if exists then return
+    # first check if given path is an absolute path and if exists then return
     for folder in walk(output_dir):
         if str(path) in str(folder):
             path = folder
@@ -1049,17 +1049,17 @@ def get_analyse(which_directory, all_weights_plus_minus_one=False,
     path = convert_input_path(which_directory)
     a = analyser(path, only_pm=all_weights_plus_minus_one)
     #a.plot_losses()
-    indexs = input_with_check_ints(
+    indexes = input_with_check_ints(
         f'which state? (int from 0 - {len(a.files)-1} or idx_1 - idx_2): ',
         [0, len(a.files)-1])
-    if len(indexs) == 1:
-        indexs.append(indexs[0])
-    for idx in range(indexs[0],indexs[1]+1):
+    if len(indexes) == 1:
+        indexes.append(indexes[0])
+    for idx in range(indexes[0],indexes[1]+1):
         a.info_statex(idx, infos=which_infos)
         if create_perfect_machting_pdf:
             a.all_perfect_matchings_to_pdf(idx)
     plt.show()
-    input('press arbitary key to exit')
+    input('press arbitrary key to exit')
     return 0
 
 

--- a/pytheus/cli.py
+++ b/pytheus/cli.py
@@ -71,7 +71,7 @@ def plot(filename, pdf):
               help='list of which infos appear in info plot')
 def analyze(which_directory, all_weights_plus_minus_one,
             create_perfect_machting_pdf, which_infos):
-    """Run anlyzer tool depending on inputs."""
+    """Run analyzer tool depending on inputs."""
     try:
         get_analyse(which_directory,
                     all_weights_plus_minus_one=all_weights_plus_minus_one,

--- a/pytheus/fancy_classes.py
+++ b/pytheus/fancy_classes.py
@@ -92,7 +92,7 @@ class Graph():  # should this be an overpowered dictionary? NOPE
             weights = [edges[key] for key in sorted(edges.keys())]
             edges = [kk if isinstance(kk, tuple) else eval(kk) for kk in sorted(edges.keys())]
 
-            # Verification of appropiate edges
+            # Verification of appropriate edges
             if all(isinstance(edge, tuple) for edge in edges):
                 if all(len(edge) == 4 for edge in edges):
                     pass  # seems legit
@@ -200,7 +200,7 @@ class Graph():  # should this be an overpowered dictionary? NOPE
     
     def __matmul__(self, other):
         '''
-        Braket operation, the inner product between the stored state. 
+        Bracket operation, the inner product between the stored state. 
         It can be used with @.
         '''
         return self.state @ other
@@ -465,7 +465,7 @@ class Graph():  # should this be an overpowered dictionary? NOPE
                 for kk, vv in self.graph.items():
                     self.graph[kk] = vv[0] * np.exp(1j * vv[1])
             else:
-                raise ValueError('The propery `imaginary` is NOT defined correctly.')
+                raise ValueError('The property `imaginary` is NOT defined correctly.')
         else:
             for kk, vv in self.graph.items():
                 self.graph[kk] = True
@@ -483,7 +483,7 @@ class Graph():  # should this be an overpowered dictionary? NOPE
                 for kk, vv in self.graph.items():
                     self.graph[kk] = [abs(vv), np.angle(vv)]
             else:
-                raise ValueError('The propery `imaginary` is NOT defined correctly.')
+                raise ValueError('The property `imaginary` is NOT defined correctly.')
         else:
             for kk, vv in self.graph.items():
                 self.graph[kk] = [True, False]
@@ -688,7 +688,7 @@ class State():
         Function to initiate a State instance with different inputs.
         This version is not so flexible with the input format as the analogous from Graph.
         '''
-        # Verification of appropiate kets
+        # Verification of appropriate kets
         if type(kets) == dict:
             amplitudes = [kets[key] for key in sorted(kets.keys())]
             kets = sorted(kets.keys())
@@ -701,7 +701,7 @@ class State():
         else:
             raise ValueError(invalidInput('kets'))
 
-        # Verification and setting of appropiate amplitudes
+        # Verification and setting of appropriate amplitudes
         if len(amplitudes) == 0:  # The default option True behaves (mostly) as 1
             amplitudes = defaultValues(len(kets), self.imaginary)
         else:
@@ -816,7 +816,7 @@ class State():
 
     def __matmul__(self, other):
         '''
-        Braket operation, the inner product between state. 
+        Bracket operation, the inner product between state. 
         It can be used with @.
         '''
         conversion_a = self.imaginary == 'polar'
@@ -937,7 +937,7 @@ class State():
                 for kk, vv in self.state.items():
                     self.state[kk] = vv[0] * np.exp(1j * vv[1])
             else:
-                raise ValueError('The propery `imaginary` is NOT defined correctly.')
+                raise ValueError('The property `imaginary` is NOT defined correctly.')
         else:
             for kk, vv in self.state.items():
                 self.state[kk] = True
@@ -955,7 +955,7 @@ class State():
                 for kk, vv in self.state.items():
                     self.state[kk] = [abs(vv), np.angle(vv)]
             else:
-                raise ValueError('The propery `imaginary` is NOT defined correctly.')
+                raise ValueError('The property `imaginary` is NOT defined correctly.')
         else:
             for kk, vv in self.state.items():
                 self.state[kk] = [True, False]

--- a/pytheus/graphs/Measurements/ghz_analyzer_2d/config_ghz_analyzer_2d.json
+++ b/pytheus/graphs/Measurements/ghz_analyzer_2d/config_ghz_analyzer_2d.json
@@ -1,5 +1,5 @@
 {
-  "description": "Measurment for three particle two-dimensional GHZ state",
+  "description": "Measurement for three particle two-dimensional GHZ state",
   "bulk_thr": 0.01,
   "edges_tried": 30,
   "foldername": "ghz_analyzer_2d",

--- a/pytheus/graphs/Measurements/ghz_analyzer_3d/config_ghz_analyzer_3d.json
+++ b/pytheus/graphs/Measurements/ghz_analyzer_3d/config_ghz_analyzer_3d.json
@@ -1,5 +1,5 @@
 {
-  "description": "Measurment for three particle three-dimensional GHZ state. Two ancillary particles",
+  "description": "Measurement for three particle three-dimensional GHZ state. Two ancillary particles",
   "bulk_thr": 0.01,
   "edges_tried": 30,
   "foldername": "ghz_analyzer_3d",

--- a/pytheus/graphs/Measurements/ghz_analyzer_4d/config_ghz_analyzer_4d.json
+++ b/pytheus/graphs/Measurements/ghz_analyzer_4d/config_ghz_analyzer_4d.json
@@ -1,5 +1,5 @@
 {
-  "description": "Measurment for three particle four-dimensional GHZ state. Four ancillary particles",
+  "description": "Measurement for three particle four-dimensional GHZ state. Four ancillary particles",
   "bulk_thr": 0.01,
   "edges_tried": 30,
   "foldername": "ghz_analyzer_4d",

--- a/pytheus/help_functions.py
+++ b/pytheus/help_functions.py
@@ -108,7 +108,7 @@ def prepEdgeList(edge_list, cnfg):
     return edge_list
 
 
-def get_all_bi_partions(num_par: int, lenght=None):
+def get_all_bi_partions(num_par: int, length=None):
 
     """
     returns all bi-partions as a generator for a given number of particles:
@@ -116,15 +116,15 @@ def get_all_bi_partions(num_par: int, lenght=None):
         e.g. : num_par = 3 : [([0], [1, 2]), ([1], [0, 2]), ([2], [0, 1])]
 
     """
-    if lenght is None or lenght == 'all':
+    if length is None or length == 'all':
         def check_len(bipar):
             return True
     else:
-        assert (type(lenght) is int and int(num_par / 2) >= lenght), \
-            "invalid lenght given(or Typeerror): int(num_par/2) > given lenght"
+        assert (type(length) is int and int(num_par / 2) >= length), \
+            "invalid length given(or Typeerror): int(num_par/2) > given length"
 
         def check_len(bipar):
-            return len(bipar) == lenght
+            return len(bipar) == length
 
     S = {i for i in range(num_par)}
     doubles = []

--- a/pytheus/leiwand.py
+++ b/pytheus/leiwand.py
@@ -61,7 +61,7 @@ def leiwand(data, name='graph'):
             optionmap[(ii, ii, True)] = f"bicolor={{col{ii}}}{{col{ii}}}"
         optionmap.update({tuple([c1, c2, False]): f"bicolor_neg={{col{c2}}}{{col{c1}}}" for c1, c2 in
                           itertools.product(range(numcolors), repeat=2)})
-        # if use f"bicolor_neg={{col{c1}}}{{col{c2}}}" will inverse the color for the negitive edges, don't know why; 
+        # if use f"bicolor_neg={{col{c1}}}{{col{c2}}}" will inverse the color for the negative edges, don't know why; 
         # print(optionmap)
         if whitespace is not None:
             print("\documentclass[border={}]{}".format(whitespace, r"{standalone}"), file=outf)
@@ -215,7 +215,7 @@ def leiwandBulk(data, cnfg, name='graph', root=""):
             optionmap[(ii, ii, True)] = f"bicolor={{col{ii}}}{{col{ii}}}"
         optionmap.update({tuple([c1, c2, False]): f"bicolor_neg={{col{c2}}}{{col{c1}}}" for c1, c2 in
                           itertools.product(range(numcolors), repeat=2)})
-        # if use f"bicolor_neg={{col{c1}}}{{col{c2}}}" will inverse the color for the negitive edges, don't know why;
+        # if use f"bicolor_neg={{col{c1}}}{{col{c2}}}" will inverse the color for the negative edges, don't know why;
         # print(optionmap)
         if whitespace is not None:
             print("\documentclass[border={}]{}".format(whitespace, r"{standalone}"), file=outf)

--- a/pytheus/optimizer.py
+++ b/pytheus/optimizer.py
@@ -183,7 +183,7 @@ class topological_opti:
 
         Returns
         -------
-        list of losses for corrosponding weights stored in result.x
+        list of losses for corresponding weights stored in result.x
 
         """
         loss_values = [result.fun]
@@ -211,7 +211,7 @@ class topological_opti:
         log.info('losses done')
         valid = False
         counter = 0
-        # repeat optimization of complete graph until a good solution is found (which satifies self.check())
+        # repeat optimization of complete graph until a good solution is found (which satisfies self.check())
         while not valid:
             # prepare optimizer
             initial_values, bounds = self.prepOptimizer(len(graph))
@@ -394,7 +394,7 @@ class topological_opti:
                                                options={'ftol': self.config['ftol']})
                 except Exception as e:
                     # if the target kets can not be produced with the given graph we can give up on this edge
-                    # it wont work
+                    # it won't work
                     reduced_graph[min_edge] = amplitude
                     print('edge necessary for producing all kets')
                     log.info('edge necessary for producing all kets')

--- a/pytheus/saver.py
+++ b/pytheus/saver.py
@@ -14,21 +14,21 @@ import json
 
 def read_json(abspath: Path) -> dict:
     """
-    return the dictonary for a given abspath that is a json file
+    return the dictionary for a given abspath that is a json file
 
     """
     with abspath.open('r', encoding="UTF-8") as openfile:
         # Reading from json file
-        dictonary = json.load(openfile)
+        dictionary = json.load(openfile)
         openfile.close()
 
-    return dictonary
+    return dictionary
 
 
 def write_json(abspath: Path, dictionary: dict,
                overwrite_existing_file = False) -> None:
     """
-    getting an Path object and a dictonary then write the dictionary
+    getting an Path object and a dictionary then write the dictionary
     in a json file for the given path
 
     """
@@ -232,4 +232,4 @@ class saver:
         file_name += str(len(graph.perfect_matchings)) + '-'
         for lo in loss:
             file_name += f'{lo:.4f}_'
-        return file_name[:-1] # delet last _
+        return file_name[:-1] # delete last _

--- a/pytheus/theseus.py
+++ b/pytheus/theseus.py
@@ -312,7 +312,7 @@ def buildAllEdges(dimensions, string=False, imaginary=False, loops=False):
     Parameters
     ----------
     dimensions : list
-        Accesible dimensions/colors for each of the nodes of the graph.
+        Accessible dimensions/colors for each of the nodes of the graph.
     string : boolean, optional
         If True, it returns a list of strings instead of tuples. 
     imaginary : boolean, str ('cartesian' or 'polar'), optional
@@ -383,7 +383,7 @@ def buildRandomGraph(dimensions, num_edges, cover_all=True, loops=False):
     Parameters
     ----------
     dimensions : list
-        Accesible dimensions/colors for each of the nodes of the graph.
+        Accessible dimensions/colors for each of the nodes of the graph.
     num_edges : int
         Number of edges of the random graph.
     cover_all : boolean, optional
@@ -420,7 +420,7 @@ def allPerfectMatchings(dimensions):
     Parameters
     ----------
     dimensions : list
-        Accesible dimensions/colors for each of the nodes of the graph.
+        Accessible dimensions/colors for each of the nodes of the graph.
         
     Returns
     -------
@@ -459,7 +459,7 @@ def allEdgeCovers(dimensions, order=0, loops=False): # This function should repl
     Parameters
     ----------
     dimensions : list
-        Accesible dimensions/colors for each of the nodes of the graph.
+        Accessible dimensions/colors for each of the nodes of the graph.
     order : int, optional
         Orders above the minimum required to cover all nodes.
         If 0, the output are only perfect machings, with all nodes having degree 1.
@@ -479,7 +479,7 @@ def allEdgeCovers(dimensions, order=0, loops=False): # This function should repl
     num_nodes = len(dimensions)
     # Given a list with N different nodes, if order>0 some nodes will have degree
     # larger than 1, i.e., their creator operators will be repeated.
-    # crowded_graph stores all ways in which these repeatitions may occur.
+    # crowded_graph stores all ways in which these repetitions may occur.
     # For N=4 and order=1: 000123, 001123, 001223, 001233, 011123, 011223...
     additions = list(itertools.combinations_with_replacement(range(num_nodes), 2 * order))
     crowded_graph = [list(range(num_nodes))] * len(additions)
@@ -824,7 +824,7 @@ def mixedTarget(ket_list, mixed_catalog, amplitudes=None, imaginary=False, targe
         List of target kets written as: [((node1, dimension1), (node2, dimension2), ...), ...].
         The kets must include ALL nodes which are NOT traced out.
     mixed_catalog : dictionary
-        Dictionary of state_catalogs that produce the kets from ket_list. The catalogs are splitted by 
+        Dictionary of state_catalogs that produce the kets from ket_list. The catalogs are split by 
         the ancilla creators, which are the keys of the mixed_catalog. 
         It can be obtained from the input `state_catalog`.  
     amplitudes : list, optional
@@ -839,7 +839,7 @@ def mixedTarget(ket_list, mixed_catalog, amplitudes=None, imaginary=False, targe
     -------
     str (if target_dict False)
         Non-normalized fidelity string with all the contributions from the reduced density matrix.
-    dictinary of str (if target_dict True)
+    dictionary of str (if target_dict True)
         Dictionary whose values are non-normalized fidelity string with all the contributions from the 
         reduced density matrix.
     
@@ -920,7 +920,7 @@ def compute_entanglement(qstate: np.array, sys_dict: dict, var_factor=0) -> floa
     Parameters
     ----------
     qstate : np.array
-        basis vector of corrosponding state as np.array
+        basis vector of corresponding state as np.array
     sys_dict : dict
         that stores essential_infos (see help_functions)
 
@@ -941,12 +941,12 @@ def compute_entanglement(qstate: np.array, sys_dict: dict, var_factor=0) -> floa
         return np.einsum('ij,ji', red, red)  # is equivalent to trace( red**2 ) but faster
 
     loss_vec = [calc_con(qstate, par[0]) for par in sys_dict['bipar_for_opti']]
-    lenght = len(loss_vec)
-    mean = sum(loss_vec) / lenght
+    length = len(loss_vec)
+    mean = sum(loss_vec) / length
     if var_factor == 0:  # no need to compute variance if factor = 0
         return mean
     else:
-        var = sum([(x - mean) ** 2 for x in loss_vec]) / (lenght)
+        var = sum([(x - mean) ** 2 for x in loss_vec]) / (length)
         return mean + var_factor * var
 
 


### PR DESCRIPTION
% `codespell --count --ignore-words-list=anc,ket,nd,returne --skip="*.pdf" --write-changes`

# https://pypi.org/project/codespell/